### PR TITLE
Automatically update zip URL on release.

### DIFF
--- a/.github/workflows/zip_updater.yml
+++ b/.github/workflows/zip_updater.yml
@@ -1,0 +1,41 @@
+name: Zip Link Updater
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Tag
+        id: get_tag
+        uses: actions/github-script@0.3.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          result-encoding: string
+          script: return context.payload.release.tag_name;
+
+      - name: Checkout Master Branch
+        uses: actions/checkout@v2.0.0
+        with:
+          ref: master
+      - name: Update Zip URL
+        uses: actions/github-script@0.3.0
+        id: update_zip
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          result-encoding: string
+          script: |
+            console.log(require("process").cwd());
+            const fs = require("fs");
+            let pkg = JSON.parse(fs.readFileSync("repository.json", {encoding: "utf8"}));
+            pkg.packages[0].link = context.payload.release.zipball_url;
+            fs.writeFileSync("repository.json", JSON.stringify(pkg, null, 2));
+
+      - name: Commit and Push
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit -m "Update .zip URL to version ${{ steps.get_tag.outputs.result }}" repository.json
+          git push "https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"


### PR DESCRIPTION
**Note**: This will automatically overwrite the `link` key in `repository.json` (specifically it will overwrite the value at `packages[0].link`) with the zip file that is autogenerated by GitHub during a [release](https://github.com/cubesolver111/TMCMapTracker/releases). This PR is fine to merge, and will have no effect until a release is created. However, ***DO NOT*** create a release until the code has been refactored out of the folder it currently is in, or the shipping .zip file will have a top-level folder.